### PR TITLE
Hardcode API base URLs

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -363,19 +363,14 @@ app.use(express.static(clientDist));
 
 // Fallback to index.html for client-side routing (SPA)
 app.get("*", (_req: Request, res: Response) => {
-  const apiUrl = process.env.RENDER_EXTERNAL_URL || "";
-  // use JSON.stringify to safely escape the string
-  const injection = `<script>window.__API_URL__ = ${JSON.stringify(apiUrl)};</script>`;
   if (indexHtml) {
-    // insert injection right before the closing </head> (if present)
-    const html = indexHtml.replace("</head>", `${injection}\n</head>`);
-    return res.status(200).send(html);
+    return res.status(200).send(indexHtml);
   }
   // fallback: send a minimal HTML if index not available
   res
     .status(200)
     .send(
-      `<!doctype html><html><head>${injection}</head><body><div id="root"></div></body></html>`,
+      "<!doctype html><html><head></head><body><div id=\"root\"></div></body></html>",
     );
 });
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -47,21 +47,13 @@ type Action =
 
 // --- Configs ---
 const USE_API = true; // flip when wiring a backend
-// API base — prefer an environment-provided value, fall back to localhost in dev.
-// Avoid referencing `process` directly in client runtime code; instead, prefer
-// values exposed on `window` or via `import.meta.env` (Vite / modern bundlers).
-// The .replace ensures there is no trailing slash when building URLs.
-const API_BASE =
-  // First prefer an explicit global set by the hosting environment / HTML
-  (
-    (typeof window !== "undefined" && (window as any).__API_URL__) ||
-    // Next, prefer build-time envs exposed via import.meta.env (Vite, Snowpack, etc.)
-    (typeof import.meta !== "undefined" &&
-      (import.meta as any).env &&
-      (import.meta as any).env.RENDER_EXTERNAL_URL) ||
-    // Finally, fall back to localhost for local dev
-    "http://localhost:3000"
-  ).replace(/\/$/, "");
+// API base — hardcode dev and production origins
+const API_BASE = (
+  typeof window !== "undefined" &&
+  ["localhost", "127.0.0.1"].includes(window.location.hostname)
+)
+  ? "http://localhost:3000"
+  : "https://format-requests.onrender.com";
 const ADMIN_KEY = "change-me";
 
 const init = (): State => {


### PR DESCRIPTION
## Summary
- Simplify API base configuration with hardcoded dev (localhost:3000) and prod (https://format-requests.onrender.com) URLs
- Remove server-side HTML injection for API URL

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bf6e15d82c8321bf5fa708aab49f3f