### PR TITLE
Fix device-scoped voting and sync with DB

### DIFF
--- a/server.js
+++ b/server.js
@@ -198,6 +198,23 @@ app.delete("/api/formats/:id", requireAdmin, async (req, res) => {
   }
 });
 
+// GET /api/votes/:deviceId
+// Returns an array of format IDs this device has voted for.
+app.get("/api/votes/:deviceId", async (req, res) => {
+  const deviceId = req.params.deviceId;
+  if (!deviceId) return res.status(400).json({ error: "missing_deviceId" });
+  try {
+    const { rows } = await pool.query(
+      "SELECT format_id FROM votes WHERE device_id = $1",
+      [deviceId]
+    );
+    res.json(rows.map((r) => r.format_id));
+  } catch (err) {
+    console.error("GET /api/votes/:deviceId error:", err);
+    res.status(500).json({ error: "db_error" });
+  }
+});
+
 // POST /api/formats/:id/vote
 // body: { deviceId: "<uuid-or-string>" }
 // Toggles vote: if not voted, insert and increment, else remove and decrement.

--- a/server.ts
+++ b/server.ts
@@ -290,6 +290,25 @@ app.delete(
 );
 
 /**
+ * GET /api/votes/:deviceId
+ * Returns an array of format IDs that the given device has voted for.
+ */
+app.get("/api/votes/:deviceId", async (req: Request, res: Response) => {
+  const deviceId = req.params.deviceId;
+  if (!deviceId) return sendError(res, 400, "missing_deviceId");
+  try {
+    const { rows } = await pool.query<{ format_id: string }>(
+      "SELECT format_id FROM votes WHERE device_id = $1",
+      [deviceId],
+    );
+    return res.json(rows.map((r) => r.format_id));
+  } catch (err) {
+    console.error("GET /api/votes/:deviceId error:", err);
+    return sendError(res, 500, "db_error");
+  }
+});
+
+/**
  * POST /api/formats/:id/vote
  * body: { deviceId: string }
  * toggles vote (insert/delete) and returns { voted, votes }


### PR DESCRIPTION
## Summary
- add API endpoint to read votes for a device
- sync client vote state with server and record server's vote result

## Testing
- `npm test` (fails: Missing script)
- `npm run build:server`
- `npm run client:build`


------
https://chatgpt.com/codex/tasks/task_e_68bf7857a8a08321a58620177208661c