### PR TITLE
feat: hide admin login behind gear icon

### DIFF
--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -1,9 +1,10 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useRef } from "react";
 import * as styles from "./Header.module.css";
 
 export default function Header({ count, adminActive, onAdminActivate }) {
   const [key, setKey] = useState("");
   const [showLogin, setShowLogin] = useState(false);
+  const inputRef = useRef(null);
 
   useEffect(() => {
     if (adminActive) {
@@ -12,8 +13,29 @@ export default function Header({ count, adminActive, onAdminActivate }) {
     }
   }, [adminActive]);
 
-  const triggerActivate = () => {
-    onAdminActivate(key);
+  useEffect(() => {
+    if (showLogin && !adminActive) {
+      inputRef.current?.focus();
+    }
+  }, [showLogin, adminActive]);
+
+  const toggleLogin = () => {
+    setShowLogin((current) => {
+      const next = !current;
+      if (!next) {
+        setKey("");
+      }
+      return next;
+    });
+  };
+
+  const triggerActivate = (event) => {
+    event.preventDefault();
+    const trimmedKey = key.trim();
+    if (!trimmedKey) {
+      return;
+    }
+    onAdminActivate(trimmedKey);
   };
 
   return (
@@ -27,26 +49,48 @@ export default function Header({ count, adminActive, onAdminActivate }) {
           </span>
           <span className={styles.admin}>
             {showLogin && !adminActive ? (
-              <>
+              <form className={styles.form} onSubmit={triggerActivate}>
+                <label className={styles.srOnly} htmlFor="admin-key">
+                  Admin access key
+                </label>
                 <input
+                  ref={inputRef}
+                  id="admin-key"
                   type="password"
                   className={styles.input}
                   placeholder="enter key"
                   value={key}
                   onChange={(e) => setKey(e.target.value)}
                 />
-                <button className={styles.button} onClick={triggerActivate}>
+                <button className={styles.button} type="submit">
                   Activate
                 </button>
-              </>
+                <button
+                  className={styles.cancel}
+                  type="button"
+                  onClick={toggleLogin}
+                >
+                  Cancel
+                </button>
+              </form>
             ) : (
-              <button
-                className={styles.gear}
-                onClick={() => setShowLogin((v) => !v)}
-                aria-label="Admin login"
-              >
-                ⚙
-              </button>
+              <>
+                {adminActive && (
+                  <span className={styles.status} role="status" aria-live="polite">
+                    Admin mode active
+                  </span>
+                )}
+                <button
+                  className={styles.gear}
+                  onClick={toggleLogin}
+                  aria-label={
+                    adminActive ? "Hide admin login" : "Show admin login"
+                  }
+                  aria-pressed={showLogin}
+                >
+                  ⚙
+                </button>
+              </>
             )}
           </span>
         </div>

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -1,8 +1,21 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import * as styles from "./Header.module.css";
 
 export default function Header({ count, adminActive, onAdminActivate }) {
   const [key, setKey] = useState("");
+  const [showLogin, setShowLogin] = useState(false);
+
+  useEffect(() => {
+    if (adminActive) {
+      setShowLogin(false);
+      setKey("");
+    }
+  }, [adminActive]);
+
+  const triggerActivate = () => {
+    onAdminActivate(key);
+  };
+
   return (
     <header className={styles.header}>
       <div className={styles.wrap}>
@@ -13,20 +26,28 @@ export default function Header({ count, adminActive, onAdminActivate }) {
             Click to upvote. One vote per format per device.
           </span>
           <span className={styles.admin}>
-            Admin mode:
-            <input
-              type="password"
-              className={styles.input}
-              placeholder="enter key"
-              value={key}
-              onChange={(e) => setKey(e.target.value)}
-            />
-            <button
-              className={styles.button}
-              onClick={() => onAdminActivate(key)}
-            >
-              {adminActive ? "Active" : "Activate"}
-            </button>
+            {showLogin && !adminActive ? (
+              <>
+                <input
+                  type="password"
+                  className={styles.input}
+                  placeholder="enter key"
+                  value={key}
+                  onChange={(e) => setKey(e.target.value)}
+                />
+                <button className={styles.button} onClick={triggerActivate}>
+                  Activate
+                </button>
+              </>
+            ) : (
+              <button
+                className={styles.gear}
+                onClick={() => setShowLogin((v) => !v)}
+                aria-label="Admin login"
+              >
+                ⚙
+              </button>
+            )}
           </span>
         </div>
       </div>

--- a/src/components/Header/Header.module.css
+++ b/src/components/Header/Header.module.css
@@ -59,3 +59,12 @@
     padding: 6px 8px;
     border-radius: 8px;
 }
+
+.gear {
+    background: transparent;
+    border: none;
+    color: var(--muted);
+    cursor: pointer;
+    font-size: 16px;
+    padding: 4px;
+}

--- a/src/components/Header/Header.module.css
+++ b/src/components/Header/Header.module.css
@@ -44,6 +44,11 @@
     align-items: center;
     gap: 8px;
 }
+.form {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
 .input {
     background: var(--card);
     border: 1px solid var(--border);
@@ -59,6 +64,17 @@
     padding: 6px 8px;
     border-radius: 8px;
 }
+.cancel {
+    background: transparent;
+    border: none;
+    color: var(--muted);
+    padding: 6px 8px;
+    border-radius: 8px;
+    cursor: pointer;
+}
+.cancel:hover {
+    color: var(--text);
+}
 
 .gear {
     background: transparent;
@@ -67,4 +83,26 @@
     cursor: pointer;
     font-size: 16px;
     padding: 4px;
+}
+.gear:hover,
+.gear:focus-visible {
+    color: var(--text);
+}
+.status {
+    color: var(--text);
+    background: var(--chip);
+    border: 1px solid var(--border);
+    padding: 4px 8px;
+    border-radius: 999px;
+}
+.srOnly {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
 }


### PR DESCRIPTION
## Summary
- Hide admin login behind a gear button in header
- Reveal password field on click and collapse after successful activation

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bfdcafe87c83219a40be338bcdf045