### PR TITLE
Refresh UI with Squarespace-inspired styling

### DIFF
--- a/src/App.module.css
+++ b/src/App.module.css
@@ -1,30 +1,32 @@
 .app {
-    --bg: #0b0e11;
-    --card: #11151a;
-    --muted: #8b98a5;
-    --text: #e6edf3;
-    --accent: #2f81f7;
-    --ok: #2ea043;
-    --planned: #b7810f;
-    --chip: #1a1f24;
-    --border: #20262d;
+    --bg: #f7f3ef;
+    --card: #ffffff;
+    --muted: #706b64;
+    --text: #1f1d1a;
+    --accent: #111111;
+    --accent-soft: #d9cfc6;
+    --chip: #ede5de;
+    --border: #e5ddd3;
     background: var(--bg);
     color: var(--text);
     min-height: 100vh;
 }
+
 .gridWrap {
     max-width: 1000px;
     margin: 0 auto;
-    padding: 0 16px;
+    padding: 0 16px 48px;
 }
+
 .grid {
     display: grid;
     grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
-    gap: 12px;
-    padding: 16px 0;
+    gap: 20px;
+    padding: 32px 0 16px;
 }
+
 .footer {
     color: var(--muted);
     font-size: 12px;
-    padding: 0 0 24px;
+    padding: 0 0 40px;
 }

--- a/src/components/AdminBar/AdminBar.module.css
+++ b/src/components/AdminBar/AdminBar.module.css
@@ -1,27 +1,39 @@
 .bar {
     max-width: 1000px;
     margin: 0 auto;
-    padding: 8px 16px;
+    padding: 16px 16px 0;
     display: flex;
-    gap: 8px;
+    gap: 10px;
     align-items: center;
     flex-wrap: wrap;
 }
+
 .input,
 .select {
     background: var(--card);
-    border: 1px solid var(--border);
+    border: 1px solid var(--accent-soft);
     color: var(--text);
-    padding: 8px;
-    border-radius: 8px;
+    padding: 10px 12px;
+    border-radius: 12px;
 }
+
 .input {
     min-width: 260px;
 }
+
 .btn {
     background: transparent;
-    border: 1px solid var(--border);
-    color: var(--text);
-    padding: 8px;
-    border-radius: 8px;
+    border: 1px solid var(--accent);
+    color: var(--accent);
+    padding: 10px 14px;
+    border-radius: 12px;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    font-weight: 600;
+}
+
+.btn:hover,
+.btn:focus-visible {
+    background: var(--accent);
+    color: #ffffff;
 }

--- a/src/components/FormatCard/FormatCard.module.css
+++ b/src/components/FormatCard/FormatCard.module.css
@@ -1,101 +1,148 @@
 .card {
     background: var(--card);
     border: 1px solid var(--border);
-    border-radius: 12px;
-    padding: 14px;
+    border-radius: 18px;
+    padding: 20px;
     display: flex;
     flex-direction: column;
-    gap: 10px;
+    gap: 14px;
+    box-shadow: 0 24px 40px -35px rgba(17, 17, 17, 0.6);
 }
+
 .title {
     display: flex;
     justify-content: space-between;
-    gap: 8px;
+    gap: 12px;
     align-items: flex-start;
 }
+
 .name {
     font-weight: 600;
+    font-size: 18px;
+    letter-spacing: -0.01em;
 }
+
 .meta {
     color: var(--muted);
     font-size: 12px;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
 }
+
 .status {
-    font-size: 12px;
-    padding: 4px 8px;
+    font-size: 11px;
+    padding: 6px 12px;
     border-radius: 999px;
-    border: 1px solid var(--border);
+    border: 1px solid transparent;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
 }
+
 .supported {
-    background: rgba(46, 160, 67, 0.15);
-    color: #9be9a8;
-    border-color: rgba(46, 160, 67, 0.35);
+    background: #ecf6f1;
+    color: #1f5b3f;
+    border-color: #c5e0d2;
 }
+
 .planned {
-    background: rgba(183, 129, 15, 0.16);
-    color: #ffd27b;
-    border-color: rgba(183, 129, 15, 0.35);
+    background: #f9f3e4;
+    color: #775c1a;
+    border-color: #ead9b9;
 }
+
 .requested {
-    background: rgba(47, 129, 247, 0.16);
-    color: #9ccaff;
-    border-color: rgba(47, 129, 247, 0.35);
+    background: #f2f0ee;
+    color: var(--accent);
+    border-color: var(--accent-soft);
 }
+
 .actions {
     display: flex;
-    gap: 8px;
+    gap: 12px;
     align-items: center;
     justify-content: space-between;
     flex-wrap: wrap;
 }
+
 .vote {
     background: transparent;
-    border: 1px solid var(--border);
-    color: var(--text);
-    padding: 8px 10px;
-    border-radius: 10px;
+    border: 1px solid var(--accent);
+    color: var(--accent);
+    padding: 10px 14px;
+    border-radius: 14px;
     display: inline-flex;
     gap: 6px;
     align-items: center;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
 }
+
 .voted {
-    background: rgba(47, 129, 247, 0.2);
-    border-color: rgba(47, 129, 247, 0.4);
+    background: var(--accent);
+    color: #ffffff;
 }
+
 .count {
     min-width: 1.5ch;
     text-align: right;
 }
+
 .pill {
     background: var(--chip);
     border: 1px solid var(--border);
-    padding: 2px 8px;
+    padding: 4px 10px;
     border-radius: 999px;
     font-size: 12px;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--muted);
 }
+
 .admin {
     margin-left: auto;
     display: flex;
     gap: 8px;
     align-items: center;
 }
+
 .select {
-    background: var(--card);
-    border: 1px solid var(--border);
+    background: #ffffff;
+    border: 1px solid var(--accent-soft);
     color: var(--text);
-    padding: 6px 8px;
-    border-radius: 8px;
+    padding: 8px 10px;
+    border-radius: 10px;
 }
+
 .btn {
     background: transparent;
-    border: 1px solid var(--border);
-    color: var(--text);
-    padding: 6px 8px;
-    border-radius: 8px;
+    border: 1px solid var(--accent);
+    color: var(--accent);
+    padding: 8px 12px;
+    border-radius: 10px;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    font-weight: 600;
 }
+
+.btn:hover,
+.btn:focus-visible {
+    background: var(--accent);
+    color: #ffffff;
+}
+
 .danger {
-    color: #ffa8a8;
+    border-color: #d45858;
+    color: #d45858;
 }
+
+.danger:hover,
+.danger:focus-visible {
+    background: #d45858;
+    color: #ffffff;
+}
+
 .locked {
     color: var(--muted);
     font-size: 12px;

--- a/src/components/Header/Header.module.css
+++ b/src/components/Header/Header.module.css
@@ -2,40 +2,42 @@
     position: sticky;
     top: 0;
     z-index: 2;
-    background: linear-gradient(
-        180deg,
-        rgba(11, 14, 17, 0.95),
-        rgba(11, 14, 17, 0.8) 70%,
-        transparent
-    );
-    backdrop-filter: saturate(180%) blur(6px);
-    padding: 16px 16px 10px;
+    background: linear-gradient(180deg, rgba(247, 243, 239, 0.96), rgba(247, 243, 239, 0.85) 70%, transparent);
+    backdrop-filter: blur(8px);
+    padding: 20px 16px 12px;
     border-bottom: 1px solid var(--border);
 }
+
 .wrap {
     max-width: 1000px;
     margin: 0 auto;
     padding: 0 16px;
 }
+
 .title {
-    margin: 0 0 6px;
-    font-size: 18px;
+    margin: 0 0 10px;
+    font-size: 28px;
+    font-weight: 600;
+    letter-spacing: -0.02em;
 }
+
 .row {
     display: flex;
-    gap: 8px;
+    gap: 10px;
     align-items: center;
     flex-wrap: wrap;
     margin-top: 8px;
 }
+
 .chip {
     background: var(--chip);
     border: 1px solid var(--border);
     color: var(--muted);
-    padding: 4px 8px;
+    padding: 6px 14px;
     border-radius: 999px;
     font-size: 12px;
 }
+
 .admin {
     margin-left: auto;
     font-size: 12px;
@@ -44,18 +46,28 @@
     align-items: center;
     gap: 8px;
 }
+
 .input {
     background: var(--card);
-    border: 1px solid var(--border);
+    border: 1px solid var(--accent-soft);
     color: var(--text);
-    padding: 6px 8px;
-    border-radius: 8px;
+    padding: 8px 10px;
+    border-radius: 999px;
     width: 160px;
 }
+
 .button {
-    background: transparent;
-    border: 1px solid var(--border);
-    color: var(--text);
-    padding: 6px 8px;
-    border-radius: 8px;
+    background: var(--accent);
+    border: 1px solid var(--accent);
+    color: #ffffff;
+    padding: 8px 14px;
+    border-radius: 999px;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+}
+
+.button:hover,
+.button:focus-visible {
+    background: #2d2a26;
+    border-color: #2d2a26;
 }

--- a/src/components/Toolbar/Toolbar.jsx
+++ b/src/components/Toolbar/Toolbar.jsx
@@ -4,44 +4,46 @@ import * as styles from "./Toolbar.module.css";
 export default function Toolbar({ query, kind, status, sort, onChange }) {
   return (
     <div className={styles.bar}>
-      <input
-        type="search"
-        placeholder="Search formats (e.g., AV1, WebM, FLAC, HEIF)"
-        className={styles.input}
-        value={query}
-        onChange={(e) => onChange({ query: e.target.value })}
-      />
-      <select
-        className={styles.select}
-        value={kind}
-        onChange={(e) => onChange({ kind: e.target.value })}
-      >
-        <option value="">All types</option>
-        <option>audio</option>
-        <option>video</option>
-        <option>image</option>
-      </select>
-      <select
-        className={styles.select}
-        value={status}
-        onChange={(e) => onChange({ status: e.target.value })}
-      >
-        <option value="">All statuses</option>
-        <option>Requested</option>
-        <option>Planned</option>
-        <option>Supported</option>
-      </select>
-      <select
-        className={styles.select}
-        value={sort}
-        onChange={(e) => onChange({ sort: e.target.value })}
-      >
-        <option value="votes-desc">Sort: Votes ↓</option>
-        <option value="votes-asc">Sort: Votes ↑</option>
-        <option value="name-asc">Sort: Name A→Z</option>
-        <option value="name-desc">Sort: Name Z→A</option>
-        <option value="newest">Sort: Newest</option>
-      </select>
+      <div className={styles.barInner}>
+        <input
+          type="search"
+          placeholder="Search formats (e.g., AV1, WebM, FLAC, HEIF)"
+          className={styles.input}
+          value={query}
+          onChange={(e) => onChange({ query: e.target.value })}
+        />
+        <select
+          className={styles.select}
+          value={kind}
+          onChange={(e) => onChange({ kind: e.target.value })}
+        >
+          <option value="">All types</option>
+          <option>audio</option>
+          <option>video</option>
+          <option>image</option>
+        </select>
+        <select
+          className={styles.select}
+          value={status}
+          onChange={(e) => onChange({ status: e.target.value })}
+        >
+          <option value="">All statuses</option>
+          <option>Requested</option>
+          <option>Planned</option>
+          <option>Supported</option>
+        </select>
+        <select
+          className={styles.select}
+          value={sort}
+          onChange={(e) => onChange({ sort: e.target.value })}
+        >
+          <option value="votes-desc">Sort: Votes ↓</option>
+          <option value="votes-asc">Sort: Votes ↑</option>
+          <option value="name-asc">Sort: Name A→Z</option>
+          <option value="name-desc">Sort: Name Z→A</option>
+          <option value="newest">Sort: Newest</option>
+        </select>
+      </div>
     </div>
   );
 }

--- a/src/components/Toolbar/Toolbar.module.css
+++ b/src/components/Toolbar/Toolbar.module.css
@@ -1,17 +1,41 @@
 .bar {
     max-width: 1000px;
     margin: 0 auto;
-    padding: 0 16px;
-    display: grid;
-    grid-template-columns: 1fr 140px 160px 120px;
-    gap: 8px;
-    margin-top: 8px;
+    padding: 12px 16px 0;
 }
-.input,
-.select {
+
+.barInner {
     background: var(--card);
     border: 1px solid var(--border);
+    border-radius: 18px;
+    box-shadow: 0 20px 35px -30px rgba(17, 17, 17, 0.65);
+    padding: 16px;
+    display: grid;
+    grid-template-columns: 1fr 140px 160px 140px;
+    gap: 12px;
+}
+
+.input,
+.select {
+    background: transparent;
+    border: 1px solid var(--accent-soft);
     color: var(--text);
-    padding: 10px;
-    border-radius: 8px;
+    padding: 10px 12px;
+    border-radius: 12px;
+}
+
+.input::placeholder {
+    color: var(--muted);
+}
+
+@media (max-width: 860px) {
+    .barInner {
+        grid-template-columns: 1fr 1fr;
+    }
+}
+
+@media (max-width: 540px) {
+    .barInner {
+        grid-template-columns: 1fr;
+    }
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,18 +1,20 @@
 * {
     box-sizing: border-box;
 }
+
 body {
     margin: 0;
-    font:
-        14px/1.4 system-ui,
-        Segoe UI,
-        Roboto,
-        Helvetica,
-        Arial;
+    font: 15px/1.5 "Helvetica Neue", Helvetica, Arial, sans-serif;
+    background: #f7f3ef;
+    color: #1f1d1a;
+    -webkit-font-smoothing: antialiased;
+    text-rendering: optimizeLegibility;
 }
+
 button {
     cursor: pointer;
 }
+
 input,
 select,
 button {


### PR DESCRIPTION
## Summary
- restyle the application shell with a Squarespace-inspired neutral color palette and updated typography
- redesign toolbar, header, admin controls, and format cards with rounded shapes, shadows, and elevated accents to match the new aesthetic
- refresh global defaults to support the lighter theme and responsive refinements

## Testing
- npm run client:build

------
https://chatgpt.com/codex/tasks/task_e_68f001a069088321affd29a29aa6e404